### PR TITLE
Moved the setting of ulimit from the startup script to the docker file.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,12 @@ RUN sed -i -e "s|.*dbms.pagecache.memory=.*|dbms.pagecache.memory=512M|g" /var/l
     && sed -i -e "s|org.neo4j.server.webadmin.rrdb.location=.*|org.neo4j.server.webadmin.rrdb.location=/tmp/rrd|g" /var/lib/neo4j/conf/neo4j-server.properties \
     && sed -i -e "s|Dneo4j.ext.udc.source=.*|Dneo4j.ext.udc.source=docker|g" /var/lib/neo4j/conf/neo4j-wrapper.conf
 
+RUN if [ -n "$NEO4J_OPEN_FILES" ]; then \
+	ulimit -n $NEO4J_OPEN_FILES > /dev/null \
+else \
+	ulimit -n 40000 > /dev/null; \
+fi
+
 VOLUME /data
 
 COPY neo4j.sh /neo4j.sh

--- a/neo4j.sh
+++ b/neo4j.sh
@@ -4,12 +4,6 @@ set -e
 NEO4J_HOME=/var/lib/neo4j
 cd $NEO4J_HOME
 
-if [ -n "$NEO4J_OPEN_FILES" ]; then
-	ulimit -n $NEO4J_OPEN_FILES > /dev/null
-else
-	ulimit -n 40000 > /dev/null
-fi
-
 # NEO4J_HEAP_MEMORY=2G
 if [ -n "$NEO4J_HEAP_MEMORY" ]; then
 	echo "wrapper.java.additional=-Xmx${NEO4J_HEAP_MEMORY}" >> $NEO4J_HOME/conf/neo4j-wrapper.conf


### PR DESCRIPTION
When I tried to run the docker file on AWS received an error similar to "ulimit: open files: cannot modify limit: Operation not permitted".  It looked similar to the issue at http://stackoverflow.com/questions/24961576/docker-error-while-creating-couchbase-ulimit-open-files-cannot-modify-limit and moving the ulimit command from the startup script to the docker file fixed the problem for me.
I am very new to docker, neo4j and bash scripts, so what I have done might be sub-optimal :-)