### PR TITLE
Move initial ulimit setting to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,8 @@ RUN sed -i -e "s|.*dbms.pagecache.memory=.*|dbms.pagecache.memory=512M|g" /var/l
     && sed -i -e "s|.*keep_logical_logs=.*|keep_logical_logs=100M size|g" /var/lib/neo4j/conf/neo4j.properties \
     && sed -i -e "s|#*remote_shell_enabled=.*|remote_shell_enabled=true|g" /var/lib/neo4j/conf/neo4j.properties \
     && sed -i -e "s|org.neo4j.server.webadmin.rrdb.location=.*|org.neo4j.server.webadmin.rrdb.location=/tmp/rrd|g" /var/lib/neo4j/conf/neo4j-server.properties \
-    && sed -i -e "s|Dneo4j.ext.udc.source=.*|Dneo4j.ext.udc.source=docker|g" /var/lib/neo4j/conf/neo4j-wrapper.conf
+    && sed -i -e "s|Dneo4j.ext.udc.source=.*|Dneo4j.ext.udc.source=docker|g" /var/lib/neo4j/conf/neo4j-wrapper.conf \
+    && ulimit -n 40000 > /dev/null
 
 VOLUME /data
 

--- a/neo4j.sh
+++ b/neo4j.sh
@@ -6,8 +6,6 @@ cd $NEO4J_HOME
 
 if [ -n "$NEO4J_OPEN_FILES" ]; then
 	ulimit -n $NEO4J_OPEN_FILES > /dev/null
-else
-	ulimit -n 40000 > /dev/null
 fi
 
 # NEO4J_HEAP_MEMORY=2G


### PR DESCRIPTION
Still allows it to be set at runtime by `$NEO4J_OPEN_FILES`. Supersedes neo4j-contrib/docker-neo4j#6.